### PR TITLE
Add cached script and simple API

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,21 @@
+import asyncio
+from flask import Flask, request, jsonify
+from megacloud import Megacloud
+
+app = Flask(__name__)
+
+@app.get("/api")
+def api():
+    file_id = request.args.get("id")
+    if not file_id:
+        return jsonify({"error": "missing id"}), 400
+    url = f"https://megacloud.blog/embed-2/v3/e-1/{file_id}?k=1&autoPlay=1&oa=0&asi=1"
+    m = Megacloud(url)
+    try:
+        data = asyncio.run(m.extract())
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    return jsonify(data)
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary
- cache `embed-1.min.js` locally and reload only when needed
- retry secret key extraction when decrypt fails
- convert CLI example to new video id
- expose a small Flask API for extraction

## Testing
- `python3 -m py_compile megacloud.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_687dbae695a88331804f132d7bdd5825