### PR TITLE
feat: add node distribution endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A MC API for extracting streaming sources from MC by file ID.
 - aiohttp
 - fastapi
 - uvicorn
+- httpx
 
 ## Installation
 
@@ -20,7 +21,7 @@ A MC API for extracting streaming sources from MC by file ID.
 
 3. Install dependencies
 
-       pip install fastapi uvicorn aiohttp
+       pip install fastapi uvicorn aiohttp httpx
 
 ## Usage
 
@@ -29,18 +30,25 @@ To run the server, simply execute:
     clear && python -m uvicorn app:app --host 0.0.0.0 --port 8446
 
 By default, Server will the API at http://127.0.0.1:8446.
+The node list starts with this local address so distribution works without extra configuration.
 
-## API Endpoint
+## API Endpoints
 
     GET /api?id=<file_id>&version=<version>
+    GET /distribute?id=<file_id>&version=<version>
+    GET /nodes
+    POST /nodes?url=<node_url>
+    DELETE /nodes?url=<node_url>
 
-## Example:
+## Examples:
 
     GET http://127.0.0.1:8446/api?id=XXXXXX&version=XX
+    GET http://127.0.0.1:8446/distribute?id=XXXXXX&version=XX
 
 ## Response:
 
     Returns a JSON with the extracted video sources and additional metadata.
+    `/distribute` responses also include the node address that processed the request.
 
 # Running the Project with Python 3.11
 
@@ -54,7 +62,7 @@ By default, Server will the API at http://127.0.0.1:8446.
 
 3. Install the project dependencies:
 
-       pip install fastapi uvicorn aiohttp
+       pip install fastapi uvicorn aiohttp httpx
 
 4. Run the project:
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from megacloud import Megacloud
+import httpx
+from typing import List
 
 app = FastAPI()
 
@@ -11,6 +13,48 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+nodes: List[str] = []
+_node_index = 0
+
+@app.get("/nodes")
+async def list_nodes():
+    return {"nodes": nodes}
+
+@app.post("/nodes")
+async def add_node(url: str):
+    if url not in nodes:
+        nodes.append(url)
+    return {"nodes": nodes}
+
+@app.delete("/nodes")
+async def remove_node(url: str):
+    try:
+        nodes.remove(url)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return {"nodes": nodes}
+
+@app.get("/distribute")
+async def distribute(id: str, version: str):
+    if not nodes:
+        raise HTTPException(status_code=503, detail="No nodes configured")
+    global _node_index
+    url = nodes[_node_index % len(nodes)]
+    _node_index += 1
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{url}/api", params={"id": id, "version": version})
+            data = resp.json()
+            content = {"node": url}
+            if isinstance(data, dict):
+                content.update(data)
+            else:
+                content["response"] = data
+            return JSONResponse(content=content, status_code=resp.status_code)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
 
 @app.get("/api")
 async def api(id: str, version: str):

--- a/app.py
+++ b/app.py
@@ -14,7 +14,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-nodes: List[str] = []
+DEFAULT_NODE = "http://localhost:8446"
+nodes: List[str] = [DEFAULT_NODE]
 _node_index = 0
 
 @app.get("/nodes")


### PR DESCRIPTION
## Summary
- manage list of worker nodes via /nodes endpoints
- add /distribute endpoint forwarding requests to node /api with round-robin
- include target node address in /distribute responses

## Testing
- `python -m py_compile app.py`
- `pip install httpx`


------
https://chatgpt.com/codex/tasks/task_e_689e5117ebac83319e76c32e3c4907dc